### PR TITLE
Remove failure propagation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10024,12 +10024,6 @@ function detectDuplicateRuns(context) {
         core.info(`Skip execution because the exact same files are concurrently checked in ${concurrentDuplicate.html_url}`);
         exitSuccess({ shouldSkip: true });
     }
-    const failedDuplicate = duplicateRuns.find((run) => {
-        return run.status === 'completed' && run.conclusion === 'failure';
-    });
-    if (failedDuplicate) {
-        logFatal(`Trigger a failure because ${failedDuplicate.html_url} has already failed with the exact same files. You can use 'workflow_dispatch' to manually enforce a re-run.`);
-    }
 }
 function detectExplicitConcurrentTrigger(context) {
     const duplicateTriggerRun = context.allRuns.find((run) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,12 +191,6 @@ function detectDuplicateRuns(context: WRunContext) {
     core.info(`Skip execution because the exact same files are concurrently checked in ${concurrentDuplicate.html_url}`);
     exitSuccess({ shouldSkip: true });
   }
-  const failedDuplicate = duplicateRuns.find((run) => {
-    return run.status === 'completed' && run.conclusion === 'failure';
-  });
-  if (failedDuplicate) {
-    logFatal(`Trigger a failure because ${failedDuplicate.html_url} has already failed with the exact same files. You can use 'workflow_dispatch' to manually enforce a re-run.`);
-  }
 }
 
 function detectExplicitConcurrentTrigger(context: WRunContext) {


### PR DESCRIPTION
In case of flaky tests, we might want to re-run tests with other methods than "workflow_dispatch".
Therefore, I believe that failure propagation brings more trouble than it's worth.
