### PR TITLE
Add default value for `github_token`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,19 +5,8 @@ on:
     - cron:  '0 12 18 * *'
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-
   build:
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
       - id: skip_check
         uses: ./ # Uses this Action in the root directory
         with:
-          github_token: ${{ github.token }}
           paths_ignore: '["**/*.md"]'
           cancel_others: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          github_token: ${{ github.token }}
           paths_ignore: '["**/README.md", "**/docs/**"]'
 
   main_job:
@@ -33,7 +32,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          github_token: ${{ github.token }}
           cancel_others: 'false'
           paths: '["src/**", "dist/**"]'
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -52,6 +50,7 @@ jobs:
       - id: skip_check
         uses: ./ # Uses this Action in the root directory
         with:
+          github_token: ${{ github.token }}
           paths_ignore: '["**/*.md"]'
           cancel_others: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Therefore, when you push changes to a branch, `skip-duplicate-actions` will canc
 
 ### `github_token`
 
-**Required** Your access token for GitHub.
+A GitHub token that only needs to access the current repo. Default `github.token`.
 
 ### `paths_ignore`
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          github_token: ${{ github.token }}
           paths_ignore: '["**/README.md", "**/docs/**"]'
 
   main_job:
@@ -141,7 +140,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          github_token: ${{ github.token }}
           cancel_others: 'false'
           paths: '["src/**", "dist/**"]'
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -153,12 +151,10 @@ jobs:
 ### Option 3: Cancellation-only
 
 If you do not care about the skip-features, then you can simply ignore the `should_skip`-output.
-In this case, the integration reduces to three lines:
+In this case, the integration reduces to the following:
 
 ```yml
   - uses: fkirc/skip-duplicate-actions@master
-    with:
-      github_token: ${{ github.token }}
 ```
 
 ## Related Projects

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
   github_token:
     description: 'Your GitHub Access Token'
     required: true
+    default: ${{ github.token }}
   paths_ignore:
     description: 'A JSON-array with ignored path patterns, e.g. something like ["**/README.md", "**/docs/**"]'
     required: false


### PR DESCRIPTION
Easier setup by not having to specify the `github_token` input.