### PR TITLE
Improve logging of paths-skipping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           paths_ignore: '["**/*.md"]'
           cancel_others: 'true'
           concurrent_skipping: 'outdated_runs'
-          skip_after_successful_duplicate: 'false'
+          skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
       - if: ${{ steps.skip_check.outputs.should_skip == 'false' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           github_token: ${{ github.token }}
           paths_ignore: '["**/*.md"]'
           cancel_others: 'true'
-          concurrent_skipping: 'outdated_runs'
+          concurrent_skipping: 'never'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
       - if: ${{ steps.skip_check.outputs.should_skip == 'false' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           github_token: ${{ github.token }}
           paths_ignore: '["**/*.md"]'
           cancel_others: 'true'
-          concurrent_skipping: 'never'
+          concurrent_skipping: 'outdated_runs'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
       - if: ${{ steps.skip_check.outputs.should_skip == 'false' }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -10110,7 +10110,7 @@ function isCommitSkippable(commit, context) {
         core.info(`Commit ${commit.html_url} is path-skipped: None of '${changedFiles}' matches against patterns '${context.paths}'`);
         return true;
     }
-    core.info(`Stop backtracking at commit ${commit.html_url}: '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
+    core.info(`Stop backtracking at commit ${commit.html_url} because '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
     return false;
 }
 const globOptions = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10110,6 +10110,7 @@ function isCommitSkippable(commit, context) {
         core.info(`Commit ${commit.html_url} is path-skipped: None of '${changedFiles}' matches against patterns '${context.paths}'`);
         return true;
     }
+    core.info(`Stop backtracking at commit ${commit.html_url}: '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
     return false;
 }
 const globOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ function isCommitSkippable(commit: ReposGetCommitResponseData, context: WRunCont
     core.info(`Commit ${commit.html_url} is path-skipped: None of '${changedFiles}' matches against patterns '${context.paths}'`);
     return true;
   }
-  core.info(`Stop backtracking at commit ${commit.html_url}: '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
+  core.info(`Stop backtracking at commit ${commit.html_url} because '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
   return false;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,7 @@ function isCommitSkippable(commit: ReposGetCommitResponseData, context: WRunCont
     core.info(`Commit ${commit.html_url} is path-skipped: None of '${changedFiles}' matches against patterns '${context.paths}'`);
     return true;
   }
+  core.info(`Stop backtracking at commit ${commit.html_url}: '${changedFiles}' are not skippable against paths '${context.paths}' or paths_ignore '${context.pathsIgnore}'`);
   return false;
 }
 


### PR DESCRIPTION
If users cannot understand why something is skipped, then this is a threat to the reliability and accountability of test-suites.
Therefore, one of the core goals of this action is traceability.

As described in https://github.com/fkirc/skip-duplicate-actions/issues/79, the current paths-skipping isn't easy to observe.
This is an attempt to improve the situation with additional logging when the backtracking-algorithms stops.