### PR TITLE
Only cancel outdated runs from the same repo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52,7 +52,7 @@ function getConcurrentSkippingOptions() {
     return Object.keys(concurrentSkippingMap);
 }
 function parseWorkflowRun(run) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d;
     const treeHash = (_a = run.head_commit) === null || _a === void 0 ? void 0 : _a.tree_id;
     if (!treeHash) {
         logFatal(`Could not find the tree hash of run ${run}`);
@@ -69,6 +69,7 @@ function parseWorkflowRun(run) {
         conclusion: (_b = run.conclusion) !== null && _b !== void 0 ? _b : null,
         html_url: run.html_url,
         branch: (_c = run.head_branch) !== null && _c !== void 0 ? _c : null,
+        repo: (_d = run.head_repository.full_name) !== null && _d !== void 0 ? _d : null,
         runId: run.id,
         workflowId,
         createdAt: run.created_at,
@@ -177,7 +178,7 @@ function cancelOutdatedRuns(context) {
             if (run.status === 'completed') {
                 return false;
             }
-            return (run.treeHash !== currentRun.treeHash && run.branch === currentRun.branch);
+            return (run.treeHash !== currentRun.treeHash && run.branch === currentRun.branch && run.repo === currentRun.repo);
         });
         if (!cancelVictims.length) {
             return core.info(`Did not find other workflow-runs to be cancelled`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ interface WorkflowRun {
   conclusion: WorkflowRunConclusion | null
   html_url: string
   branch: string | null
+  repo: string | null
   runId: number
   workflowId: number
   createdAt: string
@@ -79,6 +80,7 @@ function parseWorkflowRun(run: ActionsGetWorkflowRunResponseData): WorkflowRun {
     conclusion: (run.conclusion as WorkflowRunConclusion) ?? null,
     html_url: run.html_url,
     branch: run.head_branch ?? null,
+    repo: run.head_repository.full_name ?? null,
     runId: run.id,
     workflowId,
     createdAt: run.created_at,
@@ -204,7 +206,7 @@ async function cancelOutdatedRuns(context: WRunContext): Promise<void> {
       return false
     }
     return (
-      run.treeHash !== currentRun.treeHash && run.branch === currentRun.branch
+      run.treeHash !== currentRun.treeHash && run.branch === currentRun.branch && run.repo === currentRun.repo
     )
   })
   if (!cancelVictims.length) {


### PR DESCRIPTION
I've been encountering "phantom cancellations" in my repository https://github.com/CleverRaven/Cataclysm-DDA for a while.

I just now noticed this workflow run https://github.com/CleverRaven/Cataclysm-DDA/runs/4733504904?check_suite_focus=true
that cancelled this apparently unrelated workflow run https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/1664831265

The commonality is that the branch names match, but one is a "local" build and the other is a pull request build from a remote repository.