### PR TITLE
Remove old runs without head_commit or workflow_id from consideration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,10 +56,9 @@ function parseWorkflowRun(run) {
     const treeHash = (_a = run.head_commit) === null || _a === void 0 ? void 0 : _a.tree_id;
     if (!treeHash) {
         logFatal(`
-      Could not find the tree hash of run ${run.id} (workflow: $
-      {run.workflow_id}, name: ${run.name}, head_branch: $
-      {run.head_branch}, head_sha: ${run.head_sha}). You might have a run
-      associated with a headless or removed commit.
+      Could not find the tree hash of run ${run.id} (workflow: $ {run.workflow_id},
+      name: ${run.name}, head_branch: ${run.head_branch}, head_sha: ${run.head_sha}).
+      You might have a run associated with a headless or removed commit.
     `);
     }
     const workflowId = run.workflow_id;

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,11 +55,16 @@ function parseWorkflowRun(run) {
     var _a, _b, _c;
     const treeHash = (_a = run.head_commit) === null || _a === void 0 ? void 0 : _a.tree_id;
     if (!treeHash) {
-        logFatal(`Could not find the tree hash of run ${run}`);
+        logFatal(`
+      Could not find the tree hash of run ${run.id} (workflow: $
+      {run.workflow_id}, name: ${run.name}, head_branch: $
+      {run.head_branch}, head_sha: ${run.head_sha}). You might have a run
+      associated with a headless or removed commit.
+    `);
     }
     const workflowId = run.workflow_id;
     if (!workflowId) {
-        logFatal(`Could not find the workflow id of run ${run}`);
+        logFatal(`Could not find the workflow id of run ${run.id}`);
     }
     return {
         event: run.event,
@@ -76,7 +81,9 @@ function parseWorkflowRun(run) {
     };
 }
 function parseAllRuns(response) {
-    return response.workflow_runs.map(run => parseWorkflowRun(run));
+    return response.workflow_runs
+        .filter(run => run.head_commit && run.workflow_id)
+        .map(run => parseWorkflowRun(run));
 }
 function parseOlderRuns(response, currentRun) {
     const olderRuns = response.workflow_runs.filter(run => {
@@ -84,7 +91,9 @@ function parseOlderRuns(response, currentRun) {
         return (new Date(run.created_at).getTime() <
             new Date(currentRun.createdAt).getTime());
     });
-    return olderRuns.map(run => parseWorkflowRun(run));
+    return olderRuns
+        .filter(run => run.head_commit && run.workflow_id)
+        .map(run => parseWorkflowRun(run));
 }
 function main() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,11 +65,15 @@ interface WRunContext {
 function parseWorkflowRun(run: ActionsGetWorkflowRunResponseData): WorkflowRun {
   const treeHash = run.head_commit?.tree_id
   if (!treeHash) {
-    logFatal(`Could not find the tree hash of run ${run}`)
+    logFatal(`
+      Could not find the tree hash of run ${run.id} (workflow: $ {run.workflow_id},
+      name: ${run.name}, head_branch: ${run.head_branch}, head_sha: ${run.head_sha}).
+      You might have a run associated with a headless or removed commit.
+    `)
   }
   const workflowId = run.workflow_id
   if (!workflowId) {
-    logFatal(`Could not find the workflow id of run ${run}`)
+    logFatal(`Could not find the workflow id of run ${run.id}`)
   }
   return {
     event: run.event as WRunTrigger,
@@ -89,7 +93,9 @@ function parseWorkflowRun(run: ActionsGetWorkflowRunResponseData): WorkflowRun {
 function parseAllRuns(
   response: ActionsListWorkflowRunsResponseData
 ): WorkflowRun[] {
-  return response.workflow_runs.map(run => parseWorkflowRun(run))
+  return response.workflow_runs
+    .filter(run => run.head_commit && run.workflow_id)
+    .map(run => parseWorkflowRun(run))
 }
 
 function parseOlderRuns(
@@ -103,7 +109,9 @@ function parseOlderRuns(
       new Date(currentRun.createdAt).getTime()
     )
   })
-  return olderRuns.map(run => parseWorkflowRun(run))
+  return olderRuns
+    .filter(run => run.head_commit && run.workflow_id)
+    .map(run => parseWorkflowRun(run))
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Addresses #127 by removing older runs that lack head_commit or workflow_id from consideration (i.e. they might end up running as duplicates, but probably not). I'm not sure why these kinds of runs might exist (rebasing? manual intervention by github to delete commits?), but it seems like they do. Also added a bit more verbose logging in the rare case that the current run is lacking this info.