### PR TITLE
Adjust type import of 'Endpoints'

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-// eslint-disable-next-line import/named
-import {Endpoints} from '@octokit/types'
+import type {Endpoints} from '@octokit/types'
 import {GitHub} from '@actions/github/lib/utils'
 import micromatch from 'micromatch'
 import yaml from 'js-yaml'


### PR DESCRIPTION
Small adjustment to use `import type` instead of plain `import` for `Endpoints`, so the "eslint disable comment" is no longer required.