### PR TITLE
`should_skip` value should be documented as a str

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ One of `never`, `same_content`, `same_content_newer`, `outdated_runs`, `always`.
 
 ### `should_skip`
 
-Returns `true` if the current run should be skipped according to your configured rules. This should be evaluated for either individual steps or entire jobs.
+Returns `'true'` if the current run should be skipped according to your configured rules. This should be evaluated for either individual steps or entire jobs.
 
 ### `reason`
 


### PR DESCRIPTION
I had a bit of an evening trying to do boolean operations on `should_skip` output values, not realizing they were being cast and that the `!` operator wouldn't work on them.

The proper usage is `if: ${{ needs.<jobname>.outputs.should_skip != 'true'` }}, and if the `README.md` puts _quotes_ around the word `true` no one will mistakenly think that it behaves as `bool` by the time you're operating on it within a workflow. 