### PR TITLE
Use @types/node v16 & fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,11 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      time: 04:00
+      time: "04:00"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
-      time: 04:00
+      time: "04:00"
     open-pull-requests-limit: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
         "@types/micromatch": "^4.0.2",
-        "@types/node": "^17.0.8",
+        "@types/node": "^16.11.41",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.0.0",
         "@vercel/ncc": "^0.34.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3015,9 +3015,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/micromatch": "^4.0.2",
-    "@types/node": "^17.0.8",
+    "@types/node": "^16.11.41",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vercel/ncc": "^0.34.0",


### PR DESCRIPTION
Since this action is intended to run on Node.js v16 we stick to @types/node@16