### PR TITLE
feat: Add support for reusable workflows and previous run attempts

### DIFF
--- a/.github/workflows/caller-workflow-for-testing.yml
+++ b/.github/workflows/caller-workflow-for-testing.yml
@@ -1,0 +1,12 @@
+name: Calling Workflow Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  # This job calls the reusable workflow.
+  call_reusable_workflow:
+    uses: ./.github/workflows/reusable-workflow-for-testing.yml

--- a/.github/workflows/reusable-workflow-for-testing.yml
+++ b/.github/workflows/reusable-workflow-for-testing.yml
@@ -1,0 +1,25 @@
+name: Reusable Workflow Test
+
+on:
+  workflow_call:
+
+jobs:
+  reusable_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Skip duplicate runs
+        id: skip_check
+        uses: ./
+        with:
+          # When this workflow is re-run (e.g. manually), the previous successful attempt should cause this to be skipped.
+          include_previous_attempts_of_same_run: 'true'
+          skip_after_successful_duplicate: 'true'
+          # avoid skipping because of other concurrent runs of this workflow.
+          concurrent_skipping: 'never'
+
+      - name: A step that runs
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        run: echo "This step should only run on the first attempt of this reusable workflow."

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Example (reusable workflow in the same repo): `'.github/workflows/my-reusable-wo
 Example (reusable workflow in a different repo): `'OTHER_ORG/OTHER_REPO/.github/workflows/my-reusable-workflow-from-a-different-repo.yml'`
 Default: `undefined`
 
+### `include_previous_attempts_of_same_run`
+
+If set to true, previous attempts to run the current workflow run are considered in the skip duplicate checks.
+
+Default `'false'`
+
 ## Outputs
 
 ### `should_skip`

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ One of `never`, `same_content`, `same_content_newer`, `outdated_runs`, `always`.
 
 **Default:** `'never'`
 
+### `reusable_workflow_filepath`
+**EXPERIMENTAL**
+Setting this will retrieve the most recent 100 workflow runs that reference the specified reusable workflow file and substitute it for the usual list of workflow runs to check for matching tree hashes. If you reference a reusable workflow that behaves differently in different contexts, this will still skip the calling workflow for any successful run against the same context. Due to the limitations of the GitHub Actions API you must manually specify the full filepath of the reusable workflow.     
+
+Example (reusable workflow in the same repo): `'.github/workflows/my-reusable-workflow.yml'`
+Example (reusable workflow in a different repo): `'OTHER_ORG/OTHER_REPO/.github/workflows/my-reusable-workflow-from-a-different-repo.yml'`
+Default: `undefined`
+
 ## Outputs
 
 ### `should_skip`
@@ -299,7 +307,6 @@ jobs:
 
 > [!WARNING]  
 > If the paths_filter option is not working correctly, then you could copy the “example 1" multiple times according to your needs (see <https://github.com/fkirc/skip-duplicate-actions/issues/326> for details).
-
 
 The `paths_filter` option can be used if you have multiple jobs in a workflow and want to skip them based on different [`paths_ignore`](#paths_ignore) / [`paths`](#paths) patterns. When defining such filters, the action returns corresponding information in the [`paths_result`](#paths_result) output.
 For example in a monorepo, you might want to run jobs related to the "frontend" only if some files in the corresponding "frontend/" folder have changed and the same for "backend". This can be achieved with the following configuration:

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
   reusable_workflow_filepath:
     description: 'Use this if you want to skip duplicate runs of a reusable workflow, even when they were called from a different parent workflow. This should be the full path of the workflow from the repo root. For reusable workflows in a different repo, ensure that you specify the full path including organisation and repo name.'
     required: false
+  include_previous_attempts_of_same_run:
+    description: 'If set to true, previous attempts to run the current workflow run are considered in the skip duplicate checks.'
+    required: false
+    default: 'false'
 outputs:
   should_skip:
     description: 'Returns true if the current run should be skipped according to your configured rules'

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
     description: 'If true, make the workflow logs shorter'
     required: false
     default: 'false'
+  reusable_workflow_filepath:
+    description: 'Use this if you want to skip duplicate runs of a reusable workflow, even when they were called from a different parent workflow. This should be the full path of the workflow from the repo root. For reusable workflows in a different repo, ensure that you specify the full path including organisation and repo name.'
+    required: false
 outputs:
   should_skip:
     description: 'Returns true if the current run should be skipped according to your configured rules'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,6 +38,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator], i;
+    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -330,7 +337,8 @@ function main() {
             doNotSkip: getDoNotSkipInput('do_not_skip'),
             concurrentSkipping: getConcurrentSkippingInput('concurrent_skipping'),
             cancelOthers: core.getBooleanInput('cancel_others'),
-            skipAfterSuccessfulDuplicates: core.getBooleanInput('skip_after_successful_duplicate')
+            skipAfterSuccessfulDuplicates: core.getBooleanInput('skip_after_successful_duplicate'),
+            reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath')
         };
         const repo = github.context.repo;
         const octokit = new Octokit((0, utils_1.getOctokitOptions)(token));
@@ -356,8 +364,16 @@ function main() {
       `);
         }
         const currentRun = mapWorkflowRun(apiCurrentRun, currentTreeHash);
-        // Fetch list of runs for current workflow.
-        const { data: { workflow_runs: apiAllRuns } } = yield octokit.rest.actions.listWorkflowRuns(Object.assign(Object.assign({}, repo), { workflow_id: currentRun.workflowId, per_page: 100 }));
+        let apiAllRuns;
+        if ((inputs === null || inputs === void 0 ? void 0 : inputs.reusableWorkflowFilepath.length) > 0) {
+            // if we want all runs of a reusable workflow, we need to look at all runs, not just the current workflow
+            apiAllRuns = yield findRunsOfReusableWorkflows({ repo, octokit }, inputs.reusableWorkflowFilepath);
+        }
+        else {
+            // Fetch list of runs for current workflow.
+            const { data: { workflow_runs } } = yield octokit.rest.actions.listWorkflowRuns(Object.assign(Object.assign({}, repo), { workflow_id: currentRun.workflowId, per_page: 100 }));
+            apiAllRuns = workflow_runs;
+        }
         // List with all workflow runs.
         const allRuns = [];
         // List with older workflow runs only (used to prevent some nasty race conditions and edge cases).
@@ -437,7 +453,7 @@ function exitSuccess(args) {
             summary.push('<tr>', '<td>Changed Files</td>', `<td>${changedFiles}</td>`, '</tr>');
         }
         summary.push('</table>');
-        const skipSummary = core.getBooleanInput("skip_summary");
+        const skipSummary = core.getBooleanInput('skip_summary');
         if (!skipSummary) {
             yield core.summary.addRaw(summary.join('')).write();
         }
@@ -479,6 +495,61 @@ function getStringArrayInput(name) {
         }
         exitFail(`Input '${rawInput}' is not a valid JSON`);
     }
+}
+function findRunsOfReusableWorkflows({ octokit, repo }, reusableWorkflowFilepath, limit = 100) {
+    var _a, e_1, _b, _c;
+    var _d;
+    return __awaiter(this, void 0, void 0, function* () {
+        // remove the leading slash
+        let searchTarget = reusableWorkflowFilepath.replace(/^\/+/, '');
+        // append @ if not present anywhere in the string
+        if (!searchTarget.includes('@')) {
+            searchTarget += '@';
+        }
+        const searchTargetWithRepo = `${repo.owner}/${repo.repo}/${searchTarget}`;
+        core.debug(`Searching for reusable workflow runs using: '${searchTarget}' & '${searchTargetWithRepo}'`);
+        const foundRuns = [];
+        // This will go through all runs of the repo, 100 at a time.
+        const iterator = octokit.paginate.iterator(octokit.rest.actions.listWorkflowRunsForRepo, Object.assign(Object.assign({}, repo), { per_page: 100 // Fetch 100 at a time
+         }));
+        try {
+            for (var _e = true, iterator_1 = __asyncValues(iterator), iterator_1_1; iterator_1_1 = yield iterator_1.next(), _a = iterator_1_1.done, !_a;) {
+                _c = iterator_1_1.value;
+                _e = false;
+                try {
+                    const { data: runs } = _c;
+                    for (const run of runs) {
+                        // Check if the 'referenced_workflows' array exists and has our path
+                        const isReferenced = (_d = run.referenced_workflows) === null || _d === void 0 ? void 0 : _d.some(wf => wf.path.startsWith(searchTarget) ||
+                            wf.path.startsWith(searchTargetWithRepo));
+                        if (isReferenced) {
+                            core.debug(`Found candidate reusable workflow run: ${run.html_url}`);
+                            foundRuns.push(run);
+                        }
+                        if (foundRuns.length >= limit) {
+                            core.debug('Limit reached searching for reusable workflow runs. Stopping.');
+                            break;
+                        }
+                    }
+                    if (foundRuns.length >= limit) {
+                        break;
+                    }
+                }
+                finally {
+                    _e = true;
+                }
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (!_e && !_a && (_b = iterator_1.return)) yield _b.call(iterator_1);
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+        core.debug(`Found ${foundRuns.length} candidate reusable workflow runs.`);
+        return foundRuns;
+    });
 }
 function getDoNotSkipInput(name) {
     const rawInput = core.getInput(name);

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,6 +53,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const utils_1 = __nccwpck_require__(3030);
 const plugin_retry_1 = __nccwpck_require__(6298);
+const request_error_1 = __nccwpck_require__(537);
 const micromatch_1 = __importDefault(__nccwpck_require__(6228));
 const js_yaml_1 = __importDefault(__nccwpck_require__(1917));
 // Register 'retry' plugin with default values
@@ -338,7 +339,8 @@ function main() {
             concurrentSkipping: getConcurrentSkippingInput('concurrent_skipping'),
             cancelOthers: core.getBooleanInput('cancel_others'),
             skipAfterSuccessfulDuplicates: core.getBooleanInput('skip_after_successful_duplicate'),
-            reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath')
+            reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath'),
+            includePreviousAttemptsOfSameRun: core.getBooleanInput('include_previous_attempts_of_same_run')
         };
         const repo = github.context.repo;
         const octokit = new Octokit((0, utils_1.getOctokitOptions)(token));
@@ -374,15 +376,23 @@ function main() {
             const { data: { workflow_runs } } = yield octokit.rest.actions.listWorkflowRuns(Object.assign(Object.assign({}, repo), { workflow_id: currentRun.workflowId, per_page: 100 }));
             apiAllRuns = workflow_runs;
         }
+        if (inputs.includePreviousAttemptsOfSameRun) {
+            // add any previous attempts for the current run.
+            apiAllRuns.push(...(yield getPreviousRunAttempts({ octokit, repo, currentRun })));
+        }
         // List with all workflow runs.
         const allRuns = [];
         // List with older workflow runs only (used to prevent some nasty race conditions and edge cases).
         const olderRuns = [];
         // Check and map all runs.
         for (const run of apiAllRuns) {
-            // Filter out current run and runs that lack 'head_commit' (most likely runs associated with a headless or removed commit).
+            // Filter out the current run attempt and runs that lack 'head_commit' (most likely runs associated with a headless or removed commit).
             // See https://github.com/fkirc/skip-duplicate-actions/pull/178.
-            if (run.id !== currentRun.id && run.head_commit) {
+            if (!(run.id === currentRun.id &&
+                (!inputs.includePreviousAttemptsOfSameRun ||
+                    typeof currentRun.runAttempt === 'undefined' ||
+                    run.run_attempt === currentRun.runAttempt)) &&
+                run.head_commit) {
                 const mappedRun = mapWorkflowRun(run, run.head_commit.tree_id);
                 // Add to list of all runs.
                 allRuns.push(mappedRun);
@@ -390,6 +400,13 @@ function main() {
                 if (new Date(mappedRun.createdAt).getTime() <
                     new Date(currentRun.createdAt).getTime()) {
                     olderRuns.push(mappedRun);
+                }
+                else if (inputs.includePreviousAttemptsOfSameRun &&
+                    isPreviousAttemptAtThisRun(currentRun, mappedRun)) {
+                    olderRuns.push(mappedRun);
+                }
+                else {
+                    core.debug(`Filtered out due to createdAt time being newer than this run's creation time: ${run.html_url}`);
                 }
             }
         }
@@ -408,6 +425,7 @@ function mapWorkflowRun(run, treeHash) {
     return {
         id: run.id,
         runNumber: run.run_number,
+        runAttempt: run.run_attempt,
         event: run.event,
         treeHash,
         commitHash: run.head_sha,
@@ -618,6 +636,50 @@ function getPathsFilterInput(name) {
         }
         exitFail(`Input '${rawInput}' is invalid`);
     }
+}
+/**
+ * Fetches all previous attempts for the current workflow run.
+ * @param octokit
+ * @param repo
+ * @param currentRunId - The unique ID of the workflow run.
+ * @param currentAttempt - The current attempt
+ * @returns A promise that resolves to an array of workflow run objects.
+ */
+function getPreviousRunAttempts({ octokit, repo, currentRun: { id: currentRunId, runAttempt: currentRunAttempt } }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // We'll store all the resulting attempt objects here
+        const allAttemptsData = []; // Use a more specific type if you have it
+        let attemptNumber = 1;
+        // Use a traditional for loop to iterate from 1 to currentAttempt
+        while (typeof currentRunAttempt === 'undefined' ||
+            attemptNumber < currentRunAttempt) {
+            core.debug(`Fetching attempt ${attemptNumber}...`);
+            try {
+                // Wait for the single request to complete
+                const response = yield octokit.rest.actions.getWorkflowRunAttempt(Object.assign(Object.assign({}, repo), { run_id: currentRunId, attempt_number: attemptNumber }));
+                // Add the result to our array
+                allAttemptsData.push(response.data);
+                attemptNumber++;
+            }
+            catch (error) {
+                // This stops us from carrying on indefinitely if we don't know the current run attempt.
+                if (error instanceof request_error_1.RequestError && error.status === 404) {
+                    break;
+                }
+                // For any other error (rate limit, auth, etc.), log it and stop.
+                core.error(`Failed to retrieve attempt ${attemptNumber}`);
+                throw error; // Re-throw the unexpected error
+            }
+        }
+        core.debug('');
+        return allAttemptsData;
+    });
+}
+function isPreviousAttemptAtThisRun({ runAttempt: currentRunAttempt, id: currentRunId }, { runAttempt, id }) {
+    return (currentRunId === id &&
+        typeof runAttempt !== 'undefined' &&
+        typeof currentRunAttempt !== 'undefined' &&
+        runAttempt < currentRunAttempt);
 }
 main();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {getOctokitOptions, GitHub} from '@actions/github/lib/utils'
 import {retry} from '@octokit/plugin-retry'
+import {RequestError} from '@octokit/request-error'
 import type {Endpoints} from '@octokit/types'
 import micromatch from 'micromatch'
 import yaml from 'js-yaml'
@@ -39,6 +40,7 @@ type WorkflowRunConclusion =
 interface WorkflowRun {
   id: number
   runNumber: number
+  runAttempt: number | undefined
   event: WorkflowRunTrigger
   treeHash: string
   commitHash: string
@@ -90,6 +92,7 @@ type Inputs = {
   cancelOthers: boolean
   skipAfterSuccessfulDuplicates: boolean
   reusableWorkflowFilepath: string
+  includePreviousAttemptsOfSameRun: boolean
 }
 
 type Context = {
@@ -461,7 +464,10 @@ async function main(): Promise<void> {
     skipAfterSuccessfulDuplicates: core.getBooleanInput(
       'skip_after_successful_duplicate'
     ),
-    reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath')
+    reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath'),
+    includePreviousAttemptsOfSameRun: core.getBooleanInput(
+      'include_previous_attempts_of_same_run'
+    )
   }
 
   const repo = github.context.repo
@@ -511,6 +517,12 @@ async function main(): Promise<void> {
     apiAllRuns = workflow_runs
   }
 
+  if (inputs.includePreviousAttemptsOfSameRun) {
+    // add any previous attempts for the current run.
+    apiAllRuns.push(
+      ...(await getPreviousRunAttempts({octokit, repo, currentRun}))
+    )
+  }
   // List with all workflow runs.
   const allRuns = []
   // List with older workflow runs only (used to prevent some nasty race conditions and edge cases).
@@ -518,9 +530,17 @@ async function main(): Promise<void> {
 
   // Check and map all runs.
   for (const run of apiAllRuns) {
-    // Filter out current run and runs that lack 'head_commit' (most likely runs associated with a headless or removed commit).
+    // Filter out the current run attempt and runs that lack 'head_commit' (most likely runs associated with a headless or removed commit).
     // See https://github.com/fkirc/skip-duplicate-actions/pull/178.
-    if (run.id !== currentRun.id && run.head_commit) {
+    if (
+      !(
+        run.id === currentRun.id &&
+        (!inputs.includePreviousAttemptsOfSameRun ||
+          typeof currentRun.runAttempt === 'undefined' ||
+          run.run_attempt === currentRun.runAttempt)
+      ) &&
+      run.head_commit
+    ) {
       const mappedRun = mapWorkflowRun(run, run.head_commit.tree_id)
       // Add to list of all runs.
       allRuns.push(mappedRun)
@@ -530,6 +550,15 @@ async function main(): Promise<void> {
         new Date(currentRun.createdAt).getTime()
       ) {
         olderRuns.push(mappedRun)
+      } else if (
+        inputs.includePreviousAttemptsOfSameRun &&
+        isPreviousAttemptAtThisRun(currentRun, mappedRun)
+      ) {
+        olderRuns.push(mappedRun)
+      } else {
+        core.debug(
+          `Filtered out due to createdAt time being newer than this run's creation time: ${run.html_url}`
+        )
       }
     }
   }
@@ -551,6 +580,7 @@ function mapWorkflowRun(
   return {
     id: run.id,
     runNumber: run.run_number,
+    runAttempt: run.run_attempt,
     event: run.event as WorkflowRunTrigger,
     treeHash,
     commitHash: run.head_sha,
@@ -796,6 +826,69 @@ function getPathsFilterInput(name: string): PathsFilter {
     }
     exitFail(`Input '${rawInput}' is invalid`)
   }
+}
+
+/**
+ * Fetches all previous attempts for the current workflow run.
+ * @param octokit
+ * @param repo
+ * @param currentRunId - The unique ID of the workflow run.
+ * @param currentAttempt - The current attempt
+ * @returns A promise that resolves to an array of workflow run objects.
+ */
+async function getPreviousRunAttempts({
+  octokit,
+  repo,
+  currentRun: {id: currentRunId, runAttempt: currentRunAttempt}
+}: Pick<Context, 'octokit' | 'repo' | 'currentRun'>): Promise<
+  ApiWorkflowRun[]
+> {
+  // We'll store all the resulting attempt objects here
+  const allAttemptsData: ApiWorkflowRun[] = [] // Use a more specific type if you have it
+  let attemptNumber = 1
+  // Use a traditional for loop to iterate from 1 to currentAttempt
+  while (
+    typeof currentRunAttempt === 'undefined' ||
+    attemptNumber < currentRunAttempt
+  ) {
+    core.debug(`Fetching attempt ${attemptNumber}...`)
+    try {
+      // Wait for the single request to complete
+      const response = await octokit.rest.actions.getWorkflowRunAttempt({
+        ...repo,
+        run_id: currentRunId,
+        attempt_number: attemptNumber
+      })
+
+      // Add the result to our array
+      allAttemptsData.push(response.data)
+
+      attemptNumber++
+    } catch (error: unknown) {
+      // This stops us from carrying on indefinitely if we don't know the current run attempt.
+      if (error instanceof RequestError && error.status === 404) {
+        break
+      }
+      // For any other error (rate limit, auth, etc.), log it and stop.
+      core.error(`Failed to retrieve attempt ${attemptNumber}`)
+      throw error // Re-throw the unexpected error
+    }
+  }
+
+  core.debug('')
+  return allAttemptsData
+}
+
+function isPreviousAttemptAtThisRun(
+  {runAttempt: currentRunAttempt, id: currentRunId}: WorkflowRun,
+  {runAttempt, id}: WorkflowRun
+): boolean {
+  return (
+    currentRunId === id &&
+    typeof runAttempt !== 'undefined' &&
+    typeof currentRunAttempt !== 'undefined' &&
+    runAttempt < currentRunAttempt
+  )
 }
 
 main()

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,7 @@ type Inputs = {
   concurrentSkipping: ConcurrentSkipping
   cancelOthers: boolean
   skipAfterSuccessfulDuplicates: boolean
+  reusableWorkflowFilepath: string
 }
 
 type Context = {
@@ -459,7 +460,8 @@ async function main(): Promise<void> {
     cancelOthers: core.getBooleanInput('cancel_others'),
     skipAfterSuccessfulDuplicates: core.getBooleanInput(
       'skip_after_successful_duplicate'
-    )
+    ),
+    reusableWorkflowFilepath: core.getInput('reusable_workflow_filepath')
   }
 
   const repo = github.context.repo
@@ -490,14 +492,24 @@ async function main(): Promise<void> {
   }
   const currentRun = mapWorkflowRun(apiCurrentRun, currentTreeHash)
 
-  // Fetch list of runs for current workflow.
-  const {
-    data: {workflow_runs: apiAllRuns}
-  } = await octokit.rest.actions.listWorkflowRuns({
-    ...repo,
-    workflow_id: currentRun.workflowId,
-    per_page: 100
-  })
+  let apiAllRuns: ApiWorkflowRun[]
+  if (inputs?.reusableWorkflowFilepath.length > 0) {
+    // if we want all runs of a reusable workflow, we need to look at all runs, not just the current workflow
+    apiAllRuns = await findRunsOfReusableWorkflows(
+      {repo, octokit},
+      inputs.reusableWorkflowFilepath
+    )
+  } else {
+    // Fetch list of runs for current workflow.
+    const {
+      data: {workflow_runs}
+    } = await octokit.rest.actions.listWorkflowRuns({
+      ...repo,
+      workflow_id: currentRun.workflowId,
+      per_page: 100
+    })
+    apiAllRuns = workflow_runs
+  }
 
   // List with all workflow runs.
   const allRuns = []
@@ -611,7 +623,7 @@ async function exitSuccess(args: {
     )
   }
   summary.push('</table>')
-  const skipSummary = core.getBooleanInput("skip_summary")
+  const skipSummary = core.getBooleanInput('skip_summary')
   if (!skipSummary) {
     await core.summary.addRaw(summary.join('')).write()
   }
@@ -657,6 +669,60 @@ function getStringArrayInput(name: string): string[] {
     }
     exitFail(`Input '${rawInput}' is not a valid JSON`)
   }
+}
+
+async function findRunsOfReusableWorkflows(
+  {octokit, repo}: Pick<Context, 'octokit' | 'repo'>,
+  reusableWorkflowFilepath: string,
+  limit = 100
+): Promise<ApiWorkflowRun[]> {
+  // remove the leading slash
+  let searchTarget = reusableWorkflowFilepath.replace(/^\/+/, '')
+  // append @ if not present anywhere in the string
+  if (!searchTarget.includes('@')) {
+    searchTarget += '@'
+  }
+  const searchTargetWithRepo = `${repo.owner}/${repo.repo}/${searchTarget}`
+  core.debug(
+    `Searching for reusable workflow runs using: '${searchTarget}' & '${searchTargetWithRepo}'`
+  )
+  const foundRuns: ApiWorkflowRun[] = []
+  // This will go through all runs of the repo, 100 at a time.
+  const iterator = octokit.paginate.iterator(
+    octokit.rest.actions.listWorkflowRunsForRepo,
+    {
+      ...repo,
+      per_page: 100 // Fetch 100 at a time
+    }
+  )
+  for await (const {data: runs} of iterator) {
+    for (const run of runs) {
+      // Check if the 'referenced_workflows' array exists and has our path
+      const isReferenced = run.referenced_workflows?.some(
+        wf =>
+          wf.path.startsWith(searchTarget) ||
+          wf.path.startsWith(searchTargetWithRepo)
+      )
+
+      if (isReferenced) {
+        core.debug(`Found candidate reusable workflow run: ${run.html_url}`)
+        foundRuns.push(run)
+      }
+
+      if (foundRuns.length >= limit) {
+        core.debug(
+          'Limit reached searching for reusable workflow runs. Stopping.'
+        )
+        break
+      }
+    }
+
+    if (foundRuns.length >= limit) {
+      break
+    }
+  }
+  core.debug(`Found ${foundRuns.length} candidate reusable workflow runs.`)
+  return foundRuns
 }
 
 function getDoNotSkipInput(name: string): WorkflowRunTrigger[] {


### PR DESCRIPTION
Hey, thanks for creating and maintaining this project! It has the potential to reduce our GitHub Action minutes usage by a lot. 

We use a lot of reusable workflows, and after I saw #327 I understood that this action couldn't see duplicates if they were triggered by different parent workflows. I've added a `reusable_workflow_filepath` input that lets you tell the action to look at the history of a specific reusable workflow. This allows it to find successful duplicates no matter where they were called from.

Due to limitations in the GH API, there isn't any scope for getting info about the specifics of the reusable workflow's run only it's calling run, so this should only be used on reusable workflows that are never skipped for other reasons. 

Also, mainly for testing purposes, but possibly useful in other scenarios, I've added an `include_previous_attempts_of_same_run` input. At the moment the action will ignore all previous attempts of the current workflow. With this option enabled, the action will look at the previous attempts for the *same run* and can skip the new one if an earlier attempt already succeeded.

I also added a couple of new test workflows (`caller-workflow-for-testing.yml` and `reusable-workflow-for-testing.yml`) to make sure these new features work as expected. The test is to let the caller workflow run successfully, then manually re-run it, which should skip the second step of the reusable workflow. 

Thanks again for all your work on this. Let me know what you think 👍 

Fixes #327 